### PR TITLE
update phonedata.go 添加 中国广电1921号码段的支持

### DIFF
--- a/phonedata.go
+++ b/phonedata.go
@@ -17,6 +17,7 @@ const (
 	CTCC_v                                //电信虚拟运营商
 	CUCC_v                                //联通虚拟运营商
 	CMCC_v                                //移动虚拟运营商
+	CBN                                   //中国广播电视网络有限公司 ->简称 “中国广电”
 	INT_LEN            = 4
 	CHAR_LEN           = 1
 	HEAD_LENGTH        = 8
@@ -42,6 +43,7 @@ var (
 		CTCC_v: "中国电信虚拟运营商",
 		CUCC_v: "中国联通虚拟运营商",
 		CMCC_v: "中国移动虚拟运营商",
+		CBN:    "中国广电",
 	}
 	total_len, firstoffset int32
 )


### PR DESCRIPTION
添加中国广电1921号码段支持，需要合并先https://github.com/xluohome/phonedata/pull/48 ，才能更新号码库phone.dat文件